### PR TITLE
NetKVM: TX: Drop heavy DPC scheduling

### DIFF
--- a/NetKVM/Common/ParaNdis-Common.cpp
+++ b/NetKVM/Common/ParaNdis-Common.cpp
@@ -1889,7 +1889,7 @@ bool ParaNdis_DPCWorkBody(PARANDIS_ADAPTER *pContext, ULONG ulMaxPacketsToIndica
             pContext->CXPath.ClearInterruptReport();
         }
 
-        if (pathBundle != nullptr && pathBundle->txPath.DoPendingTasks())
+        if (pathBundle != nullptr && pathBundle->txPath.DoPendingTasks(nullptr))
         {
             stillRequiresProcessing = true;
         }

--- a/NetKVM/Common/ParaNdis-TX.h
+++ b/NetKVM/Common/ParaNdis-TX.h
@@ -235,7 +235,7 @@ public:
     ULONG GetFreeHWBuffers()
     { return m_VirtQueue.GetFreeHWBuffers(); }
 
-    bool DoPendingTasks();
+    bool DoPendingTasks(CNBL *nblHolder);
 
     void CompleteOutstandingNBLChain(PNET_BUFFER_LIST NBL, ULONG Flags = 0);
     void CompleteOutstandingInternalNBL(PNET_BUFFER_LIST NBL, BOOLEAN UnregisterOutstanding = TRUE);


### PR DESCRIPTION
In commit e8f319fdc09837dc27fce1b8abb3496593e9dc10 the lock free queue was
introduced as an alternative implementation to the previous one which
required acquiring the TX's path lock for NBLs sent by Windows. The
intention for the implementation introduced was that this lock acquirement
would be dropped in favour of scheduling a DPC upon sending an NBL instead.

While this DPC scheduling approach works it does introduce a heavy DPC
scheduling on the environment, the overhead can be as high as executing a
DPC for each NBL sent by Windows in the worst case scenario. In general
Windows should drop duplicate DPCs but it seems that it is not doing so
efficiently or else it is executing a DPC upon each schedule request by us
in a heavy load environment.

An alternative implementation which would probably allow us to keep the
DPC scheduling implementation is adding a mechanism to identify bursts and
forecast when we are receiving a high packet rate and adapt (lower) the
DPC scheduling accordingly.

This commit enables the HCK/HLK 1c_Mini6PerfSend test to pass as it was
stuck due to this heavy DPC load environment.

Signed-off-by: Sameeh Jubran <sameeh@daynix.com>