### PR TITLE
NetKVM: CX: Use separate DPC

### DIFF
--- a/NetKVM/Common/ParaNdis-CX.cpp
+++ b/NetKVM/Common/ParaNdis-CX.cpp
@@ -35,10 +35,16 @@ bool CParaNdisCX::Create(PPARANDIS_ADAPTER Context, UINT DeviceQueueIndex)
     m_Context->m_CxStateMachine.Start();
 
     CreatePath();
+    InitDPC();
 
     return m_VirtQueue.Create(DeviceQueueIndex,
         &m_Context->IODevice,
         m_Context->MiniportHandle);
+}
+
+void CParaNdisCX::InitDPC()
+{
+    KeInitializeDpc(&m_DPC, MiniportMSIInterruptCXDpc, m_Context);
 }
 
 BOOLEAN CParaNdisCX::SendControlMessage(

--- a/NetKVM/Common/ParaNdis-CX.h
+++ b/NetKVM/Common/ParaNdis-CX.h
@@ -12,6 +12,8 @@ public:
 
     virtual NDIS_STATUS SetupMessageIndex(u16 vector);
 
+    void InitDPC();
+
     BOOLEAN CParaNdisCX::SendControlMessage(
         UCHAR cls,
         UCHAR cmd,
@@ -21,6 +23,8 @@ public:
         ULONG size2,
         int levelIfOK
         );
+
+    KDPC m_DPC;
 
 protected:
     tCompletePhysicalAddress m_ControlData;

--- a/NetKVM/Common/ndis56common.h
+++ b/NetKVM/Common/ndis56common.h
@@ -539,6 +539,8 @@ bool ParaNdis_DPCWorkBody(
     PARANDIS_ADAPTER *pContext,
     ULONG ulMaxPacketsToIndicate);
 
+void ParaNdis_CXDPCWorkBody(PARANDIS_ADAPTER *pContext);
+
 void ParaNdis_ReuseRxNBLs(PNET_BUFFER_LIST pNBL);
 
 #ifdef PARANDIS_SUPPORT_RSS
@@ -841,6 +843,13 @@ tTcpIpPacketParsingResult ParaNdis_CheckSumVerifyFlat(
     SGBuffer.size = ulDataLength;
     return ParaNdis_CheckSumVerify(&SGBuffer, ulDataLength, 0, flags, verifyLength, caller);
 }
+
+VOID MiniportMSIInterruptCXDpc(
+    struct _KDPC  *Dpc,
+    IN PVOID  MiniportInterruptContext,
+    IN PVOID                  NdisReserved1,
+    IN PVOID                  NdisReserved2
+);
 
 USHORT CheckSumCalculator(PVOID buffer, ULONG len);
 

--- a/NetKVM/wlh/ParaNdis6-Impl.cpp
+++ b/NetKVM/wlh/ParaNdis6-Impl.cpp
@@ -300,9 +300,9 @@ static BOOLEAN MiniportMSIInterrupt(
     PARANDIS_STORE_LAST_INTERRUPT_TIMESTAMP(pContext);
 
     *TargetProcessors = 0;
+    *QueueDefaultInterruptDpc = FALSE;
 
     if (!pContext->bDeviceInitialized) {
-        *QueueDefaultInterruptDpc = FALSE;
         return TRUE;
     }
 
@@ -311,21 +311,26 @@ static BOOLEAN MiniportMSIInterrupt(
     path->DisableInterrupts();
     path->ReportInterrupt();
 
-
-#if NDIS_SUPPORT_NDIS620
-    if (path->DPCAffinity.Mask)
+    if (path->getMessageIndex() == pContext->CXPath.getMessageIndex())
     {
-        NdisMQueueDpcEx(pContext->InterruptHandle, MessageId, &path->DPCAffinity, NULL);
-        *QueueDefaultInterruptDpc = FALSE;
+        KeInsertQueueDpc(&pContext->CXPath.m_DPC, NULL, NULL);
     }
     else
     {
-        *QueueDefaultInterruptDpc = TRUE;
-    }
+#if NDIS_SUPPORT_NDIS620
+        if (path->DPCAffinity.Mask)
+        {
+            NdisMQueueDpcEx(pContext->InterruptHandle, MessageId, &path->DPCAffinity, NULL);
+        }
+        else
+        {
+            *QueueDefaultInterruptDpc = TRUE;
+        }
 #else
-    *TargetProcessors = (ULONG)path->DPCTargetProcessor;
-    *QueueDefaultInterruptDpc = TRUE;
+        *TargetProcessors = (ULONG)path->DPCTargetProcessor;
+        *QueueDefaultInterruptDpc = TRUE;
 #endif
+    }
 
     pContext->ulIrqReceived += 1;
     return true;
@@ -385,6 +390,26 @@ static VOID MiniportInterruptDPC(
     }
 #endif /* NDIS_SUPPORT_NDIS620 */
 
+    UNREFERENCED_PARAMETER(NdisReserved2);
+}
+
+/**********************************************************
+A CX procedure for MSI DPC handling
+Parameters:
+KDPC *  Dpc - The dpc structure for CX
+IN ULONG  MessageId - specific interrupt index
+***********************************************************/
+VOID MiniportMSIInterruptCXDpc(
+    struct _KDPC  *Dpc,
+    IN PVOID  MiniportInterruptContext,
+    IN PVOID                  NdisReserved1,
+    IN PVOID                  NdisReserved2
+)
+{
+    PARANDIS_ADAPTER *pContext = (PARANDIS_ADAPTER *)MiniportInterruptContext;
+    ParaNdis_CXDPCWorkBody(pContext);
+    UNREFERENCED_PARAMETER(Dpc);
+    UNREFERENCED_PARAMETER(NdisReserved1);
     UNREFERENCED_PARAMETER(NdisReserved2);
 }
 


### PR DESCRIPTION
This commit separates the CX path handeling to a standalone DPC, the
motive to do this is that sometimes we can miss Control interrupts due to
the way it is implemented today.

The issue is disscussed in great detail here:
https://github.com/virtio-win/kvm-guest-drivers-windows/pull/281

Signed-off-by: Sameeh Jubran <sameeh@daynix.com>