### PR TITLE
NetKVM: RHBZ#1979022: restrict JumboPacket for Win2022

### DIFF
--- a/NetKVM/netkvm-base.txt
+++ b/NetKVM/netkvm-base.txt
@@ -89,11 +89,11 @@ HKR, Ndi\params\DebugLevel,         max,        0,          "8"
 HKR, Ndi\params\DebugLevel,         step,       0,          "1"
 
 HKR, Ndi\params\*JumboPacket,       ParamDesc,  0,          %JumboPacket%
-HKR, Ndi\params\*JumboPacket,       type,       0,          "long"
+HKR, Ndi\params\*JumboPacket,       type,       0,          "enum"
 HKR, Ndi\params\*JumboPacket,       default,    0,          "1514"
-HKR, Ndi\params\*JumboPacket,       min,        0,          "590"
-HKR, Ndi\params\*JumboPacket,       max,        0,          "65500"
-HKR, Ndi\params\*JumboPacket,       step,       0,          "1"
+HKR, Ndi\params\*JumboPacket\enum,  "1514",     0,          "1514"
+HKR, Ndi\params\*JumboPacket\enum,  "4088",     0,          "4088"
+HKR, Ndi\params\*JumboPacket\enum,  "9014",     0,          "9014"
 
 HKR, Ndi\params\TxCapacity,         ParamDesc,  0,          %TxCapacity%
 HKR, Ndi\params\TxCapacity,         type,       0,          "enum"


### PR DESCRIPTION
"Devices and Components WHCP Requirements for Windows Server 2022" says:
The “*JumboPacket” standardized keyword in the Windows Registry should remain
as an enumerable value with supported values being 1514, 4088, and 9014.

So, replace JumboPacket param range [590; 65500] by enum of 3 values.

Despite of that, MTU > 9000 can still be set as virtio-net MTU parameter and
NetKVM will discard JumboPacket value and apply that MTU.

Signed-off-by: Viktor Prutyanov <viktor.prutyanov@phystech.edu>